### PR TITLE
feat(phase2): implement provider sync api

### DIFF
--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -3,4 +3,4 @@ spaceone-api
 mongoengine
 PyGithub
 schema
-yaml
+pyyaml

--- a/src/cloudforet/repository/conf/global_conf.py
+++ b/src/cloudforet/repository/conf/global_conf.py
@@ -9,3 +9,5 @@ DATABASES = {
     }
 }
 REMOTE_REPOSITORIES = []
+
+GITHUB_READ_TOKEN = ''

--- a/src/cloudforet/repository/connector/github_connector.py
+++ b/src/cloudforet/repository/connector/github_connector.py
@@ -1,0 +1,49 @@
+import logging
+
+from github import Github
+from github.GithubException import GithubException
+from spaceone.core.connector import BaseConnector
+from spaceone.core import config
+from cloudforet.repository.error.provider import *
+
+__all__ = ["GitHubConnector"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GitHubConnector(BaseConnector):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.github_client = Github()
+        self.github_read_token = config.get_global('GITHUB_READ_TOKEN', '')
+
+    def get_file(self, repo_name: str, path: str):
+        if self.github_read_token:
+            self.github_client.__init__(password=self.github_read_token)
+
+        try:
+            repo = self.github_client.get_repo(repo_name)
+            return repo.get_contents(path).decoded_content
+        except GithubException as e:
+            raise ERROR_CONNECTOR(connector='GithubConnector', reason=e)
+
+    def create_webhook(self, github_config: dict):
+        pass
+        # TODO: phase 3
+        # token = github_config['token']
+        # repo_name = github_config['repo_name']
+        # webhook_url = github_config['webhook_url']
+        # events = ["create"]
+        #
+        # webhook_config = {
+        #     'url': webhook_url,
+        #     'content_type': "json"
+        # }
+        #
+        # try:
+        #     self.github_client.__init__(password=token)
+        #     repo = self.github_client.get_repo(repo_name)
+        #     repo.create_hook('web', webhook_config, events, active=True)
+        # except GithubException as e:
+        #     raise ERROR_CONNECTOR(connector='GithubConnector', reason=e)

--- a/src/cloudforet/repository/connector/remote_repository_connector.py
+++ b/src/cloudforet/repository/connector/remote_repository_connector.py
@@ -15,14 +15,14 @@ class RemoteRepositoryConnector(BaseConnector):
         super().__init__(**kwargs)
         self.remote_repositories = config.get_global("REMOTE_REPOSITORIES", [])
 
-    def get_remote_repository(self, name):
+    def get_remote_repository(self, name: str):
         for repository in self.remote_repositories:
             if name == repository.get('name'):
                 return repository
 
         return {}
 
-    def list_remote_repositories(self, name, version):
+    def list_remote_repositories(self, name: str, version: str):
         remote_repositories = self.remote_repositories
 
         if name or version:
@@ -30,7 +30,7 @@ class RemoteRepositoryConnector(BaseConnector):
 
         return remote_repositories, len(remote_repositories)
 
-    def _filter(self, name, version):
+    def _filter(self, name: str, version: str):
         _remote_repositories = copy.deepcopy(self.remote_repositories)
 
         if name:
@@ -42,7 +42,7 @@ class RemoteRepositoryConnector(BaseConnector):
         return _remote_repositories
 
     @staticmethod
-    def _pop(key, value, remote_repositories):
+    def _pop(key: str, value: str, remote_repositories: list):
         for index, remote_repository in enumerate(remote_repositories):
             if value != remote_repository[key]:
                 del remote_repositories[index]

--- a/src/cloudforet/repository/error/provider.py
+++ b/src/cloudforet/repository/error/provider.py
@@ -5,10 +5,6 @@ class ERROR_NOT_EXIST_REQUIRED_FIELD(ERROR_INVALID_ARGUMENT):
     _message = '"{field}" field is required.'
 
 
-class ERROR_INVALID_SOURCE_TYPE(ERROR_INVALID_ARGUMENT):
-    _message = 'source_type must be GITHUB, but got "{source_type})"'
-
-
 class ERROR_INSUFFICIENT_SYNC_OPTIONS(ERROR_INVALID_ARGUMENT):
     _message = 'MANUAL or AUTOMATIC sync_options require both source_type and source. ({sync_options})'
 
@@ -17,9 +13,6 @@ class ERROR_UNSUPPORT_SYNC_MODE(ERROR_INVALID_ARGUMENT):
     _message = 'The sync api does not support the "{sync_mode}" type of sync_mode. '
 
 
-class ERROR_GITHUB_API(ERROR_INVALID_ARGUMENT):
-    _message = '{error}'
-
-
 class ERROR_INVALID_DATA_SCHEMA(ERROR_INVALID_ARGUMENT):
     _message = '{error}'
+

--- a/src/cloudforet/repository/manager/github_manager.py
+++ b/src/cloudforet/repository/manager/github_manager.py
@@ -1,0 +1,25 @@
+import logging
+import yaml
+
+from spaceone.core.manager import BaseManager
+from cloudforet.repository.connector.github_connector import GitHubConnector
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GithubManager(BaseManager):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.github_connector: GitHubConnector = self.locator.get_connector(GitHubConnector)
+
+    def get_provider(self, repo_name: str, path: str):
+        provider_file_contents = self.github_connector.get_file(repo_name, path)
+        provider_yaml = provider_file_contents.decode('utf-8')
+
+        return yaml.load(provider_yaml, Loader=yaml.Loader)
+
+    def create_webhook(self, config: dict):
+        # TODO: phase 3
+        pass
+        # self.github_connector.create_webhook(config)

--- a/src/cloudforet/repository/manager/provider_manager.py
+++ b/src/cloudforet/repository/manager/provider_manager.py
@@ -12,7 +12,7 @@ class ProviderManager(BaseManager):
         super().__init__(*args, **kwargs)
         self.provider_model: Provider = self.locator.get_model(Provider)
 
-    def create_provider(self, params):
+    def create_provider(self, params: dict):
         def _rollback(provider_vo: Provider):
             _LOGGER.info(f'[ROLLBACK] Delete provider : {provider_vo.provider}')
             provider_vo.delete()
@@ -22,7 +22,7 @@ class ProviderManager(BaseManager):
 
         return provider_vo
 
-    def update_provider(self, params):
+    def update_provider(self, params: dict):
         provider_vo: Provider = self.get_provider(params['provider'], params['domain_id'])
 
         return self.update_provider_by_vo(params, provider_vo)
@@ -36,15 +36,12 @@ class ProviderManager(BaseManager):
 
         return provider_vo.update(params)
 
-    # def sync_provider(self, params):
-    #     pass
-
-    def delete_provider(self, params):
+    def delete_provider(self, params: dict):
         provider_vo: Provider = self.get_provider(params['provider'], params['domain_id'])
         provider_vo.delete()
 
-    def get_provider(self, provider, domain_id, only=None):
+    def get_provider(self, provider: str, domain_id: str, only=None):
         return self.provider_model.get(provider=provider, domain_id=domain_id, only=only)
 
-    def list_providers(self, query):
+    def list_providers(self, query: dict):
         return self.provider_model.query(**query)

--- a/src/cloudforet/repository/manager/remote_repository_manager.py
+++ b/src/cloudforet/repository/manager/remote_repository_manager.py
@@ -15,7 +15,7 @@ class RemoteRepositoryManager(BaseManager):
         self.remote_repository_connector: RemoteRepositoryConnector = \
             self.locator.get_connector(RemoteRepositoryConnector)
 
-    def get_remote_repository(self, name):
+    def get_remote_repository(self, name: str):
         remote_repository_dict = self.remote_repository_connector.get_remote_repository(name)
 
         if remote_repository_dict:

--- a/src/cloudforet/repository/service/provider_service.py
+++ b/src/cloudforet/repository/service/provider_service.py
@@ -27,8 +27,8 @@ class ProviderService(BaseService):
             path = f'{directory}/{file}'
             provider_dict = self.github_mgr.get_provider(repo_name, path)
             self._validate_data(provider_dict)
-
-            params = dict(list(provider_dict.items()) + list(params.items()))
+            provider_dict.update(params)
+            params = provider_dict
 
         # TODO: phase 3
         # if secret_data and params['sync_mode'] == 'AUTOMATIC':

--- a/src/cloudforet/repository/service/provider_service.py
+++ b/src/cloudforet/repository/service/provider_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from schema import Schema, Or, Optional
+from schema import Schema, Or, Optional, Regex
 from spaceone.core.service import *
 from cloudforet.repository.manager.provider_manager import ProviderManager
 from cloudforet.repository.manager.github_manager import GithubManager
@@ -18,77 +18,84 @@ class ProviderService(BaseService):
 
     @transaction(append_meta={'authorization.scope': 'DOMAIN'})
     @check_required(['provider', 'name', 'domain_id'])
-    def create(self, params):
-        self._validate_data(params)
+    def create(self, params: dict):
+        params, secret_data = self._validate_data(params)
 
-        params, secret_data = self._validate_sync_options(params)
+        # Verifying that the github repository and files actually exist before creating the provider resource.
+        if params.get('sync_mode') in ['MANUAL', 'AUTOMATIC']:
+            repo_name, directory, file = self._parse_source_url(params['sync_options']['source']['url'])
+            path = f'{directory}/{file}'
+            provider_dict = self.github_mgr.get_provider(repo_name, path)
+            self._validate_data(provider_dict)
 
-        # This is code for phase 3
-        if secret_data and params['sync_mode'] == 'AUTOMATIC':
-            self._create_webhook_into_github(params, secret_data)
+            params = dict(list(provider_dict.items()) + list(params.items()))
+
+        # TODO: phase 3
+        # if secret_data and params['sync_mode'] == 'AUTOMATIC':
+        #     self._create_webhook_into_github(params, secret_data)
 
         return self.provider_mgr.create_provider(params)
 
     @transaction(append_meta={'authorization.scope': 'DOMAIN'})
     @check_required(['provider', 'domain_id'])
-    def update(self, params):
-        self._validate_data(params)
-
-        params, secret_data = self._validate_sync_options(params)
+    def update(self, params: dict):
+        params, secret_data = self._validate_data(params)
         provider_vo = self.provider_mgr.get_provider(params['provider'], params['domain_id'])
 
-        # This is code for phase 3
-        if secret_data and params['sync_mode'] == 'AUTOMATIC' and provider_vo.sync_mode != 'AUTOMATIC':
-            self._create_webhook_into_github(params, secret_data)
+        # TODO: phase 3
+        #      The code that prevent duplicate webhook creation.
+        # if secret_data and params['sync_mode'] == 'AUTOMATIC' and provider_vo.sync_mode != 'AUTOMATIC':
+        #     self._create_webhook_into_github(params, secret_data)
 
         return self.provider_mgr.update_provider_by_vo(params, provider_vo)
 
     @transaction(append_meta={'authorization.scope': 'DOMAIN'})
     @check_required(['provider', 'domain_id'])
-    def sync(self, params):
-        # This is code for phase 2
+    def sync(self, params: dict):
         provider_vo = self.get(params)
-        self._check_sync_mode(provider_vo.sync_mode)
+        self._validate_sync_mode(provider_vo.sync_mode)
 
-        repo_name = provider_vo.sync_options.source['url'].replace('https://github.com/', '')
-        path = provider_vo.sync_options.source['path']
+        repo_name, directory, file = self._parse_source_url(provider_vo['sync_options']['source']['url'])
+        path = f'{directory}/{file}'
         provider_dict = self.github_mgr.get_provider(repo_name, path)
-        self._check_sync_mode(provider_dict['sync_mode'])
 
-        provider_dict, _ = self._validate_sync_options(provider_dict)
+        provider_dict, _ = self._validate_data(provider_dict)
+        self._validate_sync_mode(provider_dict['sync_mode'])
 
         return self.provider_mgr.update_provider_by_vo(provider_dict, provider_vo)
 
     @transaction(append_meta={'authorization.scope': 'DOMAIN'})
     @check_required(['provider', 'domain_id'])
-    def get(self, params):
+    def get(self, params: dict):
         return self.provider_mgr.get_provider(params['provider'], params['domain_id'], params.get('only'))
 
     @transaction(append_meta={'authorization.scope': 'DOMAIN'})
     @check_required(['provider', 'domain_id'])
-    def delete(self, params):
+    def delete(self, params: dict):
         return self.provider_mgr.delete_provider(params)
 
     @transaction(append_meta={'authorization.scope': 'DOMAIN'})
     @check_required(['domain_id'])
     @append_query_filter(['provider', 'name', 'sync_mode', 'domain_id'])
     @append_keyword_filter(['provider', 'name'])
-    def list(self, params):
+    def list(self, params: dict):
         query = params.get('query', {})
 
         return self.provider_mgr.list_providers(query)
 
-    def _create_webhook_into_github(self, params, secret_data):
+    # TODO: phase 3
+    def _create_webhook_into_github(self, params: dict, secret_data: dict):
+        repo_name, _, _ = self._parse_source_url(params['sync_options']['source']['url'])
         config = {
-            'webhook_url': 'https://cloudforet.io', # This is temporary webhook url.
+            'webhook_url': 'https://cloudforet.io',
             'token': secret_data['token'],
-            'repo_name': params['sync_options']['source']['url'].replace('https://github.com/', '')
+            'repo_name': repo_name
 
         }
         self.github_mgr.create_webhook(config)
 
     @staticmethod
-    def _validate_sync_options(params):
+    def _validate_data(params: dict):
         secret_data = {}
 
         if not params.get('sync_mode') or params['sync_mode'] == 'NONE':
@@ -96,21 +103,23 @@ class ProviderService(BaseService):
         else:
             if not params.get('sync_options'):
                 raise ERROR_INSUFFICIENT_SYNC_OPTIONS(sync_options=params['sync_options'])
-            else:
-                if not params['sync_options'].get('source_type') or not params['sync_options'].get('source'):
-                    raise ERROR_INSUFFICIENT_SYNC_OPTIONS(sync_options=params['sync_options'])
 
-                if params['sync_options']['source_type'] != 'GITHUB':
-                    raise ERROR_INVALID_SOURCE_TYPE(source_type=params['sync_options']['source_type'])
-
-                if params['sync_options']['source'].get('secret_data'):
-                    secret_data = params['sync_options']['source'].pop('secret_data')
-
-        return params, secret_data
-
-    @staticmethod
-    def _validate_data(params):
         schema_list = {
+            'sync_mode': Schema(Or('NONE', 'MANUAL', 'AUTOMATIC')),
+            'sync_options': Schema(
+                {
+                    'source_type': 'GITHUB',
+                    'source': {
+                        'url': Regex(
+                            r'[-a-zA-Z0-9@:%._\+~#=]*\/[-a-zA-Z0-9@:%._\+~#=]*\/[-a-zA-Z0-9@:%._\+~#=]*\/[a-z]*\.yaml',
+                            error='Invalid url format, url must be "org/repo_name/directory/provider.yaml"'
+                        ),
+                        Optional('secret_data'): {
+                            'token': str
+                        },
+                    },
+                }
+            ),
             'schema': Schema([
                 {
                     'resource_type': Or('identity.ServiceAccount', 'secret.TrustedSecret', 'secret.Secret'),
@@ -141,7 +150,19 @@ class ProviderService(BaseService):
                 except Exception as e:
                     raise ERROR_INVALID_DATA_SCHEMA(error=e)
 
+        if params.get('sync_mode') in ['MANUAL', 'AUTOMATIC'] and params['sync_options']['source'].get('secret_data'):
+            secret_data = params['sync_options']['source'].pop('secret_data')
+
+        return params, secret_data
+
     @staticmethod
-    def _check_sync_mode(sync_mode):
+    def _validate_sync_mode(sync_mode: str):
         if sync_mode not in ['MANUAL', 'AUTOMATIC']:
             raise ERROR_UNSUPPORT_SYNC_MODE(sync_mode=sync_mode)
+
+    @staticmethod
+    def _parse_source_url(url):
+        repo_name = f'{url.split("/")[0]}/{url.split("/")[1]}'
+        directory = url.split("/")[2]
+        file = url.split("/")[3]
+        return repo_name, directory, file

--- a/src/cloudforet/repository/service/remote_repository_service.py
+++ b/src/cloudforet/repository/service/remote_repository_service.py
@@ -14,9 +14,9 @@ class RemoteRepositoryService(BaseService):
 
     @transaction(append_meta={'authorization.scope': 'PUBLIC'})
     @check_required(['name'])
-    def get(self, params):
+    def get(self, params: dict):
         return self.remote_repository_mgr.get_remote_repository(params['name'])
 
     @transaction(append_meta={'authorization.scope': 'PUBLIC'})
-    def list(self, params):
+    def list(self, params: dict):
         return self.remote_repository_mgr.list_remote_repositories(params.get('name'), params.get('version'))


### PR DESCRIPTION
### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
- Provider sync API has been implemented
  - User can manage provider resources using a YAML file in a public GitHub repository via the sync API
- Provider sync API now includes some of the results that we discussed.
  - Validate Data structure when `MANUAL` or `AUTOMATIC` type of provider resources are created
    - also It will be updated with the YAML file in a public GitHub repository for automation
  - `source` structure of `sync_options` has been updated
    - `source.url` and `source.path` are merged to `source.url`
  - New configuration(`GITHUB_READ_TOKEN`) has been added
    - This configuration is used to prevent API limit errors when retrieving YAML files from GitHub
    - I have a way to get the YAML file from GitHub using the requests library.
      - But, this way has the issue of caching the file.
  
### Known issue
- I've named the new configuration GITHUB_READ_TOKEN, but I still need your opinion about it.